### PR TITLE
Test and document truncated p-values

### DIFF
--- a/R/qvalue.R
+++ b/R/qvalue.R
@@ -13,7 +13,9 @@
 #' will be utilized in the internal calls made in \code{\link{qvalue}}. See \url{http://genomine.org/papers/Storey_FDR_2011.pdf}
 #' for a brief introduction to FDRs and q-values.
 #'
-#' @param p A vector of p-values (only necessary input).
+#' @param p A vector of p-values (only necessary input). Note that qvalue expects that these values are uniformly distributed 
+#' on [0,1), and under default parameter values will throw an error. If your p-value distribution is truncated, qvalue will 
+#' run with the BH procedure by setting pi0 = 1.
 #' @param fdr.level A level at which to control the FDR. Must be in (0,1]. Optional; if this is
 #' selected, a vector of TRUE and FALSE is returned that specifies
 #' whether each q-value is less than fdr.level or not.

--- a/R/qvalue.R
+++ b/R/qvalue.R
@@ -96,6 +96,9 @@ qvalue <- function(p, fdr.level = NULL, pfdr = FALSE, lfdr.out = TRUE, pi0 = NUL
   } else if (!is.null(fdr.level) && (fdr.level <= 0 || fdr.level > 1)) {
     stop("'fdr.level' must be in (0, 1].")
   }
+  if ( max(p) < 0.5 && is.null(pi0) ) {
+    stop("p-values are truncated and pi0 not set. Try running BH procedure by setting pi0 = 1")
+  } 
 
   # Calculate pi0 estimate
   if (is.null(pi0)) {


### PR DESCRIPTION
This is an attempted fix of the error where if truncated p-value distributions are input with default parameters, qvalue fails with `Error in smooth.spline(lambda, pi0, df = smooth.df)`.
This error has been raised repeatedlt, in #9, #17 and https://support.bioconductor.org/p/105623/
And I just had the same problem.

I made 2 changes to qvalue:
* help file for input `p` now describes this problem and how to fix it
* an extra test in qvalue returns an error code if `max(p) < 0.5` and `pi0 = NULL`

The goal is that users will encounter the error in the doucmentation and fix it quickly without needing to google. 